### PR TITLE
allows TMs and HIRs to use a noDB option (config files only

### DIFF
--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -8,7 +8,7 @@ import Cohort from './Cohort';
 import TeamList from './TeamList';
 
 //queries
-import { getAllCohorts } from '../queries/queries';
+import { getAllCohorts, getAllCohortsNoDb } from '../queries/queries';
 
 /*
   eslint no-underscore-dangle: ["error", { "allowAfterThis": true }]
@@ -43,9 +43,12 @@ export default class App extends React.Component {
   componentWillUnmount() {
     this._isMounted = false;
   }
-
+  //use getAllCohorts if using graphQL & DB
+  //use getAllCohortsNoDb if using config files only
   getCohorts() {
-    getAllCohorts().then((result) => {
+    const cohortsQuery = getAllCohorts;
+    //const cohortsQuery = getAllCohortsNoDb;
+    cohortsQuery().then((result) => {
       const allCohorts = result.data.data.cohorts;
       const sprintCohorts = allCohorts.filter(cohort => cohort.phase === 'sprint');
       const teamCohorts = allCohorts.filter(cohort => cohort.phase === 'project');

--- a/client/src/queries/queries.js
+++ b/client/src/queries/queries.js
@@ -11,4 +11,8 @@ const getAllCohorts = () => {
   });
 };
 
-export { getAllCohorts }
+const getAllCohortsNoDb = () => {
+  return Api.get(`${expressUrl}/cohorts`);
+}
+
+export { getAllCohorts, getAllCohortsNoDb }

--- a/server/controllers/cohortsController.js
+++ b/server/controllers/cohortsController.js
@@ -2,12 +2,24 @@
 const students = require('../../db/models/students');
 const cohorts = require('../../db/models/cohorts');
 
+//config files (if you don't want to set up a local DB)
+const allCohortsConfig = require('../config/cohorts').allCohorts;
+
 //COHORT requests TODO: error handling for all functions, delete functionality
+
+//Uncomment either line 13 or lines 16-20, depending on whether you want front use the db or config files
 exports.getCohorts = async(req, res) => {
-  const allCohorts = await cohorts.getAllCohorts();
-  const sprintCohorts = allCohorts.filter(cohort => cohort.phase === 'sprint');
-  const teamCohorts = allCohorts.filter(cohort => cohort.phase === 'project');
-  res.send({ sprintCohorts, teamCohorts });
+  //for using DB and GraphQL
+  //const allCohorts = await cohorts.getAllCohorts();
+
+  //for using config files only
+  let allCohorts = allCohortsConfig;
+  allCohorts = allCohorts.map((cohort) => {
+    cohort.cohort_name = cohort.name;
+    return cohort;
+  });
+
+  res.send({ data: {cohorts: allCohorts} });
 };
 
 exports.createCohort = async(req, res) => {


### PR DESCRIPTION
Realized the only people who will want the whole DB setup locally are devs who want to work on this project.  This allows TMs and any HIRs that just want to use the tool to use their config files exclusively.