### PR TITLE
feat(toy-problems): get cohorts list from DB instead of using hard coded values

### DIFF
--- a/client/src/components/toyProblems/ToyProblems.jsx
+++ b/client/src/components/toyProblems/ToyProblems.jsx
@@ -28,6 +28,7 @@ export default class ToyProblems extends Component {
     this.setState({ selectedCohort }, () => this.checkToyProblems());
   }
 
+  // TODO: get only active cohorts
   getCohortsList() {
     getAllCohorts().then(result => {
       const cohorts = result.data.data.cohorts.map(e => e.name.toUpperCase());

--- a/client/src/components/toyProblems/ToyProblems.jsx
+++ b/client/src/components/toyProblems/ToyProblems.jsx
@@ -2,9 +2,8 @@ import React, { Component } from 'react';
 import { Button } from 'semantic-ui-react';
 import axios from 'axios';
 import StudentPrDetails from './StudentPrDetails';
+import { getAllCohorts } from '../../queries/queries';
 
-// TODO: Get cohortslist from DB/ config
-const COHORTS = ['RPT13', 'RPT14', 'RPT15'];
 const { GHOSTBUSTER_BASE_URL } = process.env;
 
 export default class ToyProblems extends Component {
@@ -21,12 +20,21 @@ export default class ToyProblems extends Component {
   }
 
   componentDidMount() {
-    this.setState({ allCohorts: COHORTS });
+    this.getCohortsList();
   }
 
   onButtonClick(e) {
     const selectedCohort = e.target.innerHTML.toLowerCase();
     this.setState({ selectedCohort }, () => this.checkToyProblems());
+  }
+
+  getCohortsList() {
+    getAllCohorts().then(result => {
+      const cohorts = result.data.data.cohorts.map(e => e.name.toUpperCase());
+      this.setState({
+        allCohorts: cohorts
+      });
+    });
   }
 
   checkToyProblems() {

--- a/server/helpers/toyProblemsChecker.js
+++ b/server/helpers/toyProblemsChecker.js
@@ -52,7 +52,8 @@ const getPrListForStudent = async (cohort, student) => {
       const pullRequests = response.items.map(item => {
         return item.title;
       });
-      const matchedPrs = AllPrsWithMatchingTitles(pullRequests) || [];
+      let matchedPrs = AllPrsWithMatchingTitles(pullRequests) || [];
+      matchedPrs = [...new Set(matchedPrs)];
       const uniqueMatchedPrCount = numberOfUniquePrsWithMatchingTitles(matchedPrs);
       return { cohort, studentName, studentGithubHandle, matchedPrs, uniqueMatchedPrCount };
     }


### PR DESCRIPTION
This PR includes: 

- Generating cohorts list from DB instead of using hardcoded values
- Remove duplicate pr titles from the student card. Screenshot before/ after:
![image](https://user-images.githubusercontent.com/4053857/61799964-f408ae80-ade0-11e9-8659-474a2ceee26e.png)
