### PR TITLE
feat(teams): add confirmation and other usability improvements

### DIFF
--- a/client/src/components/admin/teams/CreateTeamModal.jsx
+++ b/client/src/components/admin/teams/CreateTeamModal.jsx
@@ -35,7 +35,7 @@ class CreateTeamModal extends Component {
   createTeam = () => {
     const { teamName, teamType } = this.state;
     let { github } = this.state;
-    const { selectedCohort, selectedStudents } = this.props;
+    const { selectedCohort, selectedStudents, close } = this.props;
     github = !github ? `${teamType}_${teamName}` : github;
     axios
       .post(
@@ -52,7 +52,7 @@ class CreateTeamModal extends Component {
               axios
                 .post(`${GHOSTBUSTER_BASE_URL}/ghostbuster/teams/${teamId}/students/${id}`)
                 .then(res => {
-                  console.log('res', res);
+                  if (res.data && res.status === 200) close();
                 });
             });
           }

--- a/client/src/components/admin/teams/CreateTeamModal.jsx
+++ b/client/src/components/admin/teams/CreateTeamModal.jsx
@@ -17,7 +17,8 @@ class CreateTeamModal extends Component {
     this.state = {
       teamName: '',
       teamType: '',
-      github: ''
+      github: '',
+      openConfirmationModal: false
     };
   }
 
@@ -31,6 +32,8 @@ class CreateTeamModal extends Component {
   };
 
   handleSelectionChange = (e, { value }) => this.setState({ teamType: value });
+
+  handleClose = () => this.setState({ openConfirmationModal: false });
 
   createTeam = () => {
     const { teamName, teamType } = this.state;
@@ -52,7 +55,10 @@ class CreateTeamModal extends Component {
               axios
                 .post(`${GHOSTBUSTER_BASE_URL}/ghostbuster/teams/${teamId}/students/${id}`)
                 .then(res => {
-                  if (res.data && res.status === 200) close();
+                  if (res.data && res.status === 200) {
+                    close();
+                    this.setState({ openConfirmationModal: true });
+                  }
                 });
             });
           }
@@ -65,6 +71,7 @@ class CreateTeamModal extends Component {
 
   render() {
     const { open, selectedStudents, close } = this.props;
+    const { openConfirmationModal, teamName } = this.state;
 
     return (
       <div>
@@ -116,6 +123,28 @@ class CreateTeamModal extends Component {
               content="Create Team?"
               onClick={this.createTeam}
             />
+          </Modal.Actions>
+        </Modal>
+        <Modal open={openConfirmationModal} size="mini">
+          <Modal.Header>Success!</Modal.Header>
+          <Modal.Content style={{ fontSize: '18px' }}>
+            Created New Team:
+            <span>
+              <b style={{ color: 'green' }}>{`  ${teamName}`}</b>
+            </span>
+            <List style={{ fontSize: '15px' }}>
+              <List.Header>With Students:</List.Header>
+              {selectedStudents.map(student => (
+                <List.Item key={student.github}>
+                  {`- ${student.firstName} ${student.lastName}`}
+                </List.Item>
+              ))}
+            </List>
+          </Modal.Content>
+          <Modal.Actions>
+            <Button positive onClick={this.handleClose}>
+              OK
+            </Button>
           </Modal.Actions>
         </Modal>
       </div>

--- a/client/src/components/admin/teams/ManageTeams.jsx
+++ b/client/src/components/admin/teams/ManageTeams.jsx
@@ -20,6 +20,7 @@ function ManageTeams(props) {
         buttonLabel="Manage Teams"
       />
       <TeamsList
+        style={{ marginLeft: '50px', marginTop: '15px' }}
         teamsListForSelectedCohort={teamsListForSelectedCohort}
         selectedCohort={selectedCohort}
         showTeamDetails={showTeamDetails}

--- a/client/src/components/admin/teams/StudentsList.jsx
+++ b/client/src/components/admin/teams/StudentsList.jsx
@@ -44,8 +44,10 @@ class StudentsList extends Component {
   };
 
   close = () => {
+    const { studentsList } = this.state;
     this.setState({
-      open: false
+      open: false,
+      studentsList: studentsList.map(student => Object.assign(student, { isChecked: false }))
     });
   };
 
@@ -69,6 +71,7 @@ class StudentsList extends Component {
               <Checkbox
                 label={`${student.firstName} ${student.lastName}`}
                 style={{ fontSize: '18px' }}
+                checked={student.isChecked}
               />
             </List.Item>
           ))}

--- a/client/src/components/admin/teams/StudentsList.jsx
+++ b/client/src/components/admin/teams/StudentsList.jsx
@@ -39,7 +39,8 @@ class StudentsList extends Component {
     }
 
     this.setState({
-      studentsList: currentList
+      studentsList: currentList,
+      selectedStudents: studentsList.filter(student => student.isChecked)
     });
   };
 
@@ -47,7 +48,8 @@ class StudentsList extends Component {
     const { studentsList } = this.state;
     this.setState({
       open: false,
-      studentsList: studentsList.map(student => Object.assign(student, { isChecked: false }))
+      studentsList: studentsList.map(student => Object.assign(student, { isChecked: false })),
+      selectedStudents: []
     });
   };
 
@@ -76,7 +78,13 @@ class StudentsList extends Component {
             </List.Item>
           ))}
         </List>
-        <Button onClick={() => this.handleButtonClick()}>Create Team</Button>
+        {selectedStudents.length ? (
+          <Button color="blue" onClick={() => this.handleButtonClick()}>
+            Create Team
+          </Button>
+        ) : (
+          <Button disabled>Create Team</Button>
+        )}
         <CreateTeamModal
           close={this.close}
           selectedStudents={selectedStudents}

--- a/client/src/components/admin/teams/TeamsList.jsx
+++ b/client/src/components/admin/teams/TeamsList.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Card, Button, Confirm } from 'semantic-ui-react';
+import { Card, Button, Confirm, Icon } from 'semantic-ui-react';
 import _ from 'lodash';
 import axios from 'axios';
 
@@ -43,13 +43,21 @@ class TeamsList extends Component {
     return (
       <React.Fragment>
         {Object.keys(teamsByTeamType).map(teamType => (
-          <div key={teamType}>
+          <div key={teamType} style={{ padding: '10px', margin: 'auto', width: '90%' }}>
             <h1>{`${teamType} teams`}</h1>
             <Card.Group>
               {teamsByTeamType[teamType].map(team => (
-                <Card key={team.teamId}>
+                <Card key={team.teamId} style={{ margin: '20px' }}>
                   <Card.Content>
                     <Card.Header>{team.teamName}</Card.Header>
+                    <Card.Meta>
+                      <p>
+                        <Icon name="github" />
+                        <span>{team.github}</span>
+                      </p>
+                    </Card.Meta>
+                  </Card.Content>
+                  <Card.Content>
                     <Card.Description>
                       {team.students.map(student => (
                         <li key={student.studentId}>{student.name}</li>
@@ -80,6 +88,7 @@ class TeamsList extends Component {
               onCancel={this.closeConfirmationModal}
               onConfirm={this.handleDeleteButtonClick}
               content="Delete Team?"
+              dimmer="blurring"
               size="mini"
             />
           </div>

--- a/client/src/components/admin/teams/TeamsList.jsx
+++ b/client/src/components/admin/teams/TeamsList.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Card, Button } from 'semantic-ui-react';
+import { Card, Button, Confirm } from 'semantic-ui-react';
 import _ from 'lodash';
 import axios from 'axios';
 
@@ -10,28 +10,35 @@ class TeamsList extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      selectedTeamId: null
+      selectedTeamId: null,
+      openConfirmationModal: false
     };
   }
 
   deleteTeam = teamId => {
     const { showTeamDetails } = this.props;
     axios.delete(`${GHOSTBUSTER_BASE_URL}/ghostbuster/teams/${teamId}`).then(response => {
-      if (response.data && response.status === 200);
-      showTeamDetails();
+      if (response.data && response.status === 200) {
+        showTeamDetails();
+        this.setState({ openConfirmationModal: false });
+      }
     });
   };
 
-  handleDeleteButtonClick = e => {
-    this.setState({ selectedTeamId: e.target.value }, () => {
-      const { selectedTeamId } = this.state;
-      this.deleteTeam(selectedTeamId);
-    });
+  handleDeleteButtonClick = () => {
+    const { selectedTeamId } = this.state;
+    this.deleteTeam(selectedTeamId);
   };
+
+  openConfirmationModal = e =>
+    this.setState({ openConfirmationModal: true, selectedTeamId: e.target.value });
+
+  closeConfirmationModal = () => this.setState({ openConfirmationModal: false });
 
   render() {
     const { teamsListForSelectedCohort } = this.props;
     const teamsByTeamType = _.groupBy(teamsListForSelectedCohort, 'teamType');
+    const { openConfirmationModal } = this.state;
 
     return (
       <React.Fragment>
@@ -51,13 +58,14 @@ class TeamsList extends Component {
                   </Card.Content>
                   <Card.Content extra>
                     <div>
+                      {/* #TODO: implement edit team feature */}
                       <Button basic color="blue" disabled value={team.teamId}>
                         Edit Team
                       </Button>
                       <Button
                         basic
                         color="red"
-                        onClick={this.handleDeleteButtonClick}
+                        onClick={this.openConfirmationModal}
                         value={team.teamId}
                       >
                         Delete Team
@@ -67,6 +75,13 @@ class TeamsList extends Component {
                 </Card>
               ))}
             </Card.Group>
+            <Confirm
+              open={openConfirmationModal}
+              onCancel={this.closeConfirmationModal}
+              onConfirm={this.handleDeleteButtonClick}
+              content="Delete Team?"
+              size="mini"
+            />
           </div>
         ))}
       </React.Fragment>


### PR DESCRIPTION
This PR includes
1. Close modal after creating a team
2. Display confirmation modal after creating a team
3. Display confirmation modal before deleting team
4. Enable create team button when at least one entry in the list is selected
5. Clear selection when navigating away from the `Create Team` modal
6. Add team github handle to `team card`
6. Minor ui clean-up