### PR TITLE
fix(commit counts): exclude no fork message from commit count

### DIFF
--- a/client/src/components/CommitList.jsx
+++ b/client/src/components/CommitList.jsx
@@ -7,6 +7,9 @@ import sprints from '../../../server/config/sprints';
 
 const CommitList = props => {
   const { commits, url, show, handleCommitChange, sprint } = props;
+  const commitsExcludingNoForkMessage = commits.filter(
+    commit => !commit.normalizedMessage.includes('no fork')
+  );
 
   //  TODO: need to update while using DB
   const { messages } = sprints.allSprints[sprint];
@@ -51,7 +54,9 @@ const CommitList = props => {
         <Label as="a" color="teal" onClick={handleCommitChange} size="large">
           <Icon name="github" />
           Total # of Commits:
-          <Label.Detail>{commits.length ? commits.length : 0}</Label.Detail>
+          <Label.Detail>
+            {commitsExcludingNoForkMessage.length ? commitsExcludingNoForkMessage.length : 0}
+          </Label.Detail>
         </Label>
         <Label as="a" color="blue" onClick={handleCommitChange} size="large">
           # of Milestone Commits:


### PR DESCRIPTION
This pr fixes a bug where we were not excluding `no fork` message as one commit. 