### PR TITLE
feat(student-card): add option to view list of only milestone commit messages

### DIFF
--- a/client/src/components/AppWithoutAuth.jsx
+++ b/client/src/components/AppWithoutAuth.jsx
@@ -6,7 +6,7 @@ import { BrowserRouter as Router, Route } from 'react-router-dom';
 import { Container } from 'semantic-ui-react';
 import Home from './Home';
 import TopNav from './TopNav';
-import Cohort from './Cohort';
+import Cohort from './sprints/Cohort';
 import ToyProblems from './toyProblems/ToyProblems';
 import Admin from './admin/Admin';
 import Attendance from './attendance/Attendance';

--- a/client/src/components/sprints/CommitList.jsx
+++ b/client/src/components/sprints/CommitList.jsx
@@ -7,7 +7,15 @@ import sprints from '../../../../server/config/sprints';
 import utils from '../../../../common/utils';
 
 const CommitList = props => {
-  const { commits, url, show, handleCommitChange, sprint } = props;
+  const {
+    commits,
+    url,
+    show,
+    showMilestoneCommits,
+    handleCommitChange,
+    handleMilestoneCommitsChange,
+    sprint
+  } = props;
   const isNoFork = commits.length === 1 && commits[0].message === 'no fork';
 
   //  TODO: need to update while using DB
@@ -53,6 +61,34 @@ const CommitList = props => {
   ) : (
     <List />
   );
+
+  const filteredMilestoneCommits = [
+    ...new Set(
+      commits.filter(
+        commit =>
+          milestoneCommits.includes(commit.normalizedMessage) ||
+          milestoneCommits.some(
+            message => utils.getSimilarityPercentage(message, commit.normalizedMessage) >= 0.87
+          )
+      )
+    )
+  ];
+
+  const milestoneCommitsList = showMilestoneCommits ? (
+    filteredMilestoneCommits.map((commit, i) => (
+      <List.Item key={i}>
+        <StarIconGreen name="star" />
+        <List.Content style={{ textAlign: 'left' }}>
+          <a target="_blank" rel="noopener noreferrer" href={url}>
+            <strong style={{ color: 'green' }}>{commit.message}</strong>
+          </a>
+        </List.Content>
+      </List.Item>
+    ))
+  ) : (
+    <List />
+  );
+
   const noForkMessage = (
     <Label basic color="red" size="huge">
       No Fork
@@ -67,7 +103,7 @@ const CommitList = props => {
           Total # of Commits:
           <Label.Detail>{commits.length && !isNoFork ? commits.length : 0}</Label.Detail>
         </Label>
-        <Label as="a" color="blue" onClick={handleCommitChange} size="large">
+        <Label as="a" color="blue" onClick={handleMilestoneCommitsChange} size="large">
           # of Milestone Commits:
           <Label.Detail>
             {uniqueMilestoneCommits.length ? uniqueMilestoneCommits.length : 0}
@@ -75,7 +111,7 @@ const CommitList = props => {
         </Label>
       </Label.Group>
       <List divided relaxed>
-        {commitList}
+        {show && !showMilestoneCommits ? commitList : milestoneCommitsList}
       </List>
     </>
   );

--- a/client/src/components/sprints/StudentCard.jsx
+++ b/client/src/components/sprints/StudentCard.jsx
@@ -6,17 +6,29 @@ import CommitList from './CommitList';
 
 class StudentCard extends React.Component {
   state = {
-    showCommits: false
+    showCommits: false,
+    showMilestoneCommits: false
   };
 
   handleShowCommitsChange = () => {
     const { showCommits } = this.state;
-    this.setState({ showCommits: !showCommits });
+    this.setState({
+      showCommits: !showCommits,
+      showMilestoneCommits: false
+    });
+  };
+
+  handleShowMilestoneCommitsChange = () => {
+    const { showMilestoneCommits } = this.state;
+    this.setState({
+      showMilestoneCommits: !showMilestoneCommits,
+      showCommits: false
+    });
   };
 
   render() {
     const { student, repoName } = this.props;
-    const { showCommits } = this.state;
+    const { showCommits, showMilestoneCommits } = this.state;
     const githubUrl = `http://www.github.com/${student.github}/${student.cohort}-${repoName}`;
 
     return (
@@ -30,6 +42,8 @@ class StudentCard extends React.Component {
               <CommitList
                 handleCommitChange={this.handleShowCommitsChange}
                 show={showCommits}
+                showMilestoneCommits={showMilestoneCommits}
+                handleMilestoneCommitsChange={this.handleShowMilestoneCommitsChange}
                 url={githubUrl}
                 commits={student.commitMessages}
                 sprint={repoName}


### PR DESCRIPTION
**Current behavior:**
Displays list of all commits on clicking `Total # of commits` or `# of Milestone Commits` button

**Updated behavior:**
Displays list of all commits on clicking `Total # of commits`  button
Displays list of milestone commits on clicking `# of Milestone Commits` button

This will help us to filter milestone commit messages when there are a lot of commits in a repo (example: mini apps)